### PR TITLE
Modify: 브런치 게시글 포스팅 기획 변경

### DIFF
--- a/src/main/kotlin/com/lgmpjt/ittrendbackend/utils/SeleniumUtils.kt
+++ b/src/main/kotlin/com/lgmpjt/ittrendbackend/utils/SeleniumUtils.kt
@@ -47,23 +47,19 @@ class SeleniumUtils {
                 }
             }
 
-            var postElementList: List<WebElement> = driver.findElements(By.cssSelector(".wrap_article_list .list_article .list_has_image a.link_post"))
+            val postElementList: List<WebElement> = driver.findElements(By.cssSelector(".wrap_article_list .list_article .list_has_image a.link_post"))
             for (pe in postElementList) {
                 // 초기에는 게시글 내용을 그대로 가져와서 화면에 출력해주는 형태로 구상하였으나, 해당 사이트의 서버에 저장된 이미지로 게시글을 작성하여 이미지를 가져오기 어려운 상황이 있는 등 여러 문제가 존재하다.
                 // 따라서 게시글의 링크를 크롤링하여 링크의 리스트를 화면에 출력해주는 형태의 앱으로 기획을 변경한다.
-                var postLink: String = pe.getAttribute("href")
-                println("---------")
-                println(postLink)
-                driver.get(postLink)
-                Thread.sleep(2000)
-
                 // 게시글을 구별하기 위해 게시글의 제목과 등록일자를 수집한다.
                 // brunch의 경우 등록일자가 없고, O분 전 형태로 시간을 출력해주기 때문에 등록일자를 따로 수집하지 않는다.
-                var titleElement: WebElement = driver.findElement(By.cssSelector("h1.cover_title"))
-                println("----TITLE----")
-                println(titleElement.text)
+                var childElement: WebElement = pe.findElement(By.cssSelector(".post_title strong.tit_subject"))
 
-                driver.navigate().back()
+                var postLink: String = pe.getAttribute("href")
+                var postText: String = childElement.text
+                println("---------")
+                println(postLink)
+                println(postText)
             }
         } catch (e: InterruptedException) {
             println("Catch InterruptedException: " + e.message)

--- a/src/main/kotlin/com/lgmpjt/ittrendbackend/utils/SeleniumUtils.kt
+++ b/src/main/kotlin/com/lgmpjt/ittrendbackend/utils/SeleniumUtils.kt
@@ -49,22 +49,21 @@ class SeleniumUtils {
 
             var postElementList: List<WebElement> = driver.findElements(By.cssSelector(".wrap_article_list .list_article .list_has_image a.link_post"))
             for (pe in postElementList) {
+                // 초기에는 게시글 내용을 그대로 가져와서 화면에 출력해주는 형태로 구상하였으나, 해당 사이트의 서버에 저장된 이미지로 게시글을 작성하여 이미지를 가져오기 어려운 상황이 있는 등 여러 문제가 존재하다.
+                // 따라서 게시글의 링크를 크롤링하여 링크의 리스트를 화면에 출력해주는 형태의 앱으로 기획을 변경한다.
                 var postLink: String = pe.getAttribute("href")
                 println("---------")
                 println(postLink)
                 driver.get(postLink)
                 Thread.sleep(2000)
 
+                // 게시글을 구별하기 위해 게시글의 제목과 등록일자를 수집한다.
+                // brunch의 경우 등록일자가 없고, O분 전 형태로 시간을 출력해주기 때문에 등록일자를 따로 수집하지 않는다.
                 var titleElement: WebElement = driver.findElement(By.cssSelector("h1.cover_title"))
                 println("----TITLE----")
                 println(titleElement.text)
 
-                var textElementList: List<WebElement> = driver.findElements(By.cssSelector(".wrap_body_frame .wrap_body p.item_type_text"))
-                for (te in textElementList) {
-                    println("----POST----")
-                    // TODO:: post text에서 빈 값이나 <br/>과 같은 개행 문자는 제거해야 한다.
-                    println(te.text)
-                }
+                driver.navigate().back()
             }
         } catch (e: InterruptedException) {
             println("Catch InterruptedException: " + e.message)


### PR DESCRIPTION
 - 전체 내용을 크롤링하지 않고 게시글 링크를 크롤링한다.
 - 기본적으로 게시글 데이터는 게시글 링크, 타이틀 (게시글 제목), 작성일자 를 크롤링하되, 작성일자는 없는 서비스도 있으므로 생략 가능하다.